### PR TITLE
Feat: Select and edit multiple objects

### DIFF
--- a/src/layouts/ColorPicker.cpp
+++ b/src/layouts/ColorPicker.cpp
@@ -4,11 +4,13 @@ ImVec4 ColorPicker::getNormalizedColor() const {
   return normalizedColor;
 }
 
-void ColorPicker::createColorPicker(ofColor &color) {
+bool ColorPicker::createColorPicker(ofColor &color) {
+  bool changed = false;
   normalizedColor = color;
   ImGui::Text("Color picker:");
   if (ImGui::ColorPicker3("Color Picker", (float *)&normalizedColor, ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoLabel)) {
     color = normalizedColor;
+    changed = true;
   }
 
   ImGui::Text("RGB slider:");
@@ -19,6 +21,7 @@ void ColorPicker::createColorPicker(ofColor &color) {
   if (rUsed || gUsed || bUsed) {
     normalizedColor = rgbToNormalized(ImVec4(rSlider, gSlider, bSlider, normalizedColor.w));
     color = normalizedColor;
+    changed = true;
   } else {
     ImVec4 rgb = normalizedToRgb(normalizedColor);
     rSlider = rgb.x;
@@ -34,12 +37,14 @@ void ColorPicker::createColorPicker(ofColor &color) {
   if (hUsed || sUsed || BUsed) {
     normalizedColor = hsbToNormalized(ImVec4(hSlider, sSlider, BSlider, normalizedColor.w));
     color = normalizedColor;
+    changed = true;
   } else {
     ImVec4 hsb = normalizedToHsb(normalizedColor);
     hSlider = hsb.x;
     sSlider = hsb.y;
     BSlider = hsb.z;
   }
+  return changed;
 }
 
 ImVec4 ColorPicker::normalizedToRgb(const ImVec4 &normalized) {

--- a/src/layouts/ColorPicker.h
+++ b/src/layouts/ColorPicker.h
@@ -5,7 +5,7 @@
 class ColorPicker {
 public:
   ImVec4 getNormalizedColor() const;
-  void createColorPicker(ofColor &color);
+  bool createColorPicker(ofColor &color);
 
 private:
   ImVec4 normalizedColor;

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -103,8 +103,6 @@ void ofApp::drawSceneElementMenu() {
   ImGui::SetNextWindowPos(ImVec2(ofGetWindowPositionX(), ofGetWindowPositionY()), ImGuiCond_Always);
   ImGui::SetNextWindowSize(ImVec2(200, ofGetHeight()), ImGuiCond_Always);
   if (ImGui::Begin("Scene Element", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse)) {
-    this->sceneGraph->drawSceneGraphElements();
-
     if (ImGui::Button("Add Sphere", ImVec2(180, 30))) {
       currentElementToAdd = ElementType::SPHERE;
       this->cursor.setCursorMode(CursorMode::ADDING);
@@ -123,6 +121,8 @@ void ofApp::drawSceneElementMenu() {
     if (ImGui::Button("Remove Element", ImVec2(180, 30))) {
       this->cursor.setCursorMode(CursorMode::REMOVING);
     }
+
+    this->sceneGraph->drawSceneGraphElements();
 
     ImGui::End();
   }

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -90,7 +90,7 @@ void ofApp::drawPropertiesPanel() {
   ImGui::SetNextWindowPos(ImVec2(ofGetWindowPositionX() + ofGetWidth() - window_width, ofGetWindowPositionY()), ImGuiCond_Always);
   ImGui::SetNextWindowSize(ImVec2(window_width, ofGetHeight()), ImGuiCond_Always);
   if (ImGui::Begin("PropertiesPanel", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse)) {
-    this->propertiesPanel->drawPanel(this->sceneManager->getSelectedObjectReference());
+    this->propertiesPanel->drawPropertiesPanel(this->sceneManager->getSelectedObjectReference());
     ImGui::End();
   }
 }

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -89,7 +89,7 @@ void ofApp::drawPropertiesPanel() {
   float window_width = 200.f;
   ImGui::SetNextWindowPos(ImVec2(ofGetWindowPositionX() + ofGetWidth() - window_width, ofGetWindowPositionY()), ImGuiCond_Always);
   ImGui::SetNextWindowSize(ImVec2(window_width, ofGetHeight()), ImGuiCond_Always);
-  if (ImGui::Begin("PropertiesPanel", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse)) {
+  if (ImGui::Begin("PropertiesPanel", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize)) {
     this->propertiesPanel->drawPropertiesPanel(this->sceneManager->getSelectedObjectReference());
     ImGui::End();
   }
@@ -102,7 +102,7 @@ bool ofApp::isMouseClickInScene() {
 void ofApp::drawSceneElementMenu() {
   ImGui::SetNextWindowPos(ImVec2(ofGetWindowPositionX(), ofGetWindowPositionY()), ImGuiCond_Always);
   ImGui::SetNextWindowSize(ImVec2(200, ofGetHeight()), ImGuiCond_Always);
-  if (ImGui::Begin("Scene Element", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse)) {
+  if (ImGui::Begin("Scene Element", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize)) {
     if (ImGui::Button("Add Sphere", ImVec2(180, 30))) {
       currentElementToAdd = ElementType::SPHERE;
       this->cursor.setCursorMode(CursorMode::ADDING);
@@ -134,7 +134,7 @@ void ofApp::drawSceneTopMenu() {
 
   ImGui::PushStyleColor(ImGuiCol_MenuBarBg, (ImVec4)ImColor(51, 56, 68, 255)); // Set the color of the menu bar
 
-  if (ImGui::Begin("Menu bar", nullptr, ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoBackground)) {
+  if (ImGui::Begin("Menu bar", nullptr, ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoResize)) {
     if (ImGui::BeginMenuBar()) {
       createFileMenu();
       createViewMenu();

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -209,7 +209,11 @@ void ofApp::processMouseActions() {
 
   if (ImGui::IsMouseReleased(ImGuiMouseButton_Left) && isMouseClickInScene()) {
     if (found && this->cursor.getCursorMode() == CursorMode::NAVIGATION) {
-      sceneManager->setSelectedSceneObject(foundSceneObject);
+      if (ImGui::IsKeyDown(ImGui::GetKeyIndex(ImGuiKey_LeftCtrl))) {
+        sceneManager->clickSelectionSceneObject(foundSceneObject);
+      } else {
+        sceneManager->setSelectedSceneObject(foundSceneObject);
+      }
 
     } else if (found && this->cursor.getCursorMode() == CursorMode::REMOVING) {
       sceneManager->removeObject(foundSceneObject); // TODO : Ajouter une nouvelle m�thode pour supprimer un objet

--- a/src/properties/PropertiesPanel.cpp
+++ b/src/properties/PropertiesPanel.cpp
@@ -22,18 +22,23 @@ PropertiesPanel::PropertiesPanel() {
 void PropertiesPanel::drawFloatProperty(std::vector<PropertyBase *> &objectsProperty) {
   auto firstObjectProperty = dynamic_cast<Property<float> *>(objectsProperty[0]);
   auto propertyValue = firstObjectProperty->getValue();
+
   ImGui::SeparatorText(toString(firstObjectProperty->getId()));
-  if (ImGui::SliderFloat(" ", &propertyValue, MIN_FLOAT_VALUE, MAX_FLOAT_VALUE, NULL)) { // Returns true if the value was changed
+
+  if (ImGui::SliderFloat(toString(firstObjectProperty->getId()), &propertyValue, MIN_FLOAT_VALUE, MAX_FLOAT_VALUE, NULL, ImGuiSliderFlags_AlwaysClamp)) { // Returns true if the value was changed
     for (auto &&objectProperty : objectsProperty) {
       auto property = dynamic_cast<Property<float> *>(objectProperty);
       property->setValue(propertyValue);
     }
   }
+  ImGui::SetItemTooltip("CTRL+Click to input value.");
 }
 
 void PropertiesPanel::drawColorProperty(std::vector<PropertyBase *> &objectsProperty) {
   auto firstObjectProperty = dynamic_cast<Property<ofColor> *>(objectsProperty[0]);
   auto propertyValue = firstObjectProperty->getValue();
+
+  ImGui::SeparatorText(toString(firstObjectProperty->getId()));
 
   if (this->colorPicker.createColorPicker(propertyValue)) { // Returns true if the value was changed
     for (auto &&objectProperty : objectsProperty) {
@@ -44,6 +49,9 @@ void PropertiesPanel::drawColorProperty(std::vector<PropertyBase *> &objectsProp
 }
 
 void PropertiesPanel::drawImageImport(std::vector<PropertyBase *> &objectsProperty) {
+  auto firstObjectProperty = dynamic_cast<Property<ofImage> *>(objectsProperty[0]);
+  ImGui::SeparatorText(toString(firstObjectProperty->getId()));
+
   if (ImGui::Button("Import image", ImVec2(100.f, 30.f))) { // Returns true if the button was pressed
     ImageImporter::importImage(objectsProperty);
   }

--- a/src/properties/PropertiesPanel.cpp
+++ b/src/properties/PropertiesPanel.cpp
@@ -3,6 +3,9 @@
 #include "ImageImporter.h"
 #include "imgui.h"
 
+const float PropertiesPanel::MIN_FLOAT_VALUE = 0.0f;
+const float PropertiesPanel::MAX_FLOAT_VALUE = 500.0f;
+
 PropertiesPanel::PropertiesPanel() {
   auto floatDraw = [this](std::vector<PropertyBase *> &objectsProperty) { drawFloatProperty(objectsProperty); };
   auto imageImportDraw = [this](std::vector<PropertyBase *> &objectsProperty) { drawImageImport(objectsProperty); };
@@ -20,7 +23,7 @@ void PropertiesPanel::drawFloatProperty(std::vector<PropertyBase *> &objectsProp
   auto firstObjectProperty = dynamic_cast<Property<float> *>(objectsProperty[0]);
   auto propertyValue = firstObjectProperty->getValue();
 
-  if (ImGui::SliderFloat(toString(firstObjectProperty->getId()), &propertyValue, 0.f, 500.f, "size")) {
+  if (ImGui::SliderFloat(toString(firstObjectProperty->getId()), &propertyValue, MIN_FLOAT_VALUE, MAX_FLOAT_VALUE, "size")) { // Returns true if the value was changed
     for (auto &&objectProperty : objectsProperty) {
       auto property = dynamic_cast<Property<float> *>(objectProperty);
       property->setValue(propertyValue);
@@ -32,7 +35,7 @@ void PropertiesPanel::drawColorProperty(std::vector<PropertyBase *> &objectsProp
   auto firstObjectProperty = dynamic_cast<Property<ofColor> *>(objectsProperty[0]);
   auto propertyValue = firstObjectProperty->getValue();
 
-  if (this->colorPicker.createColorPicker(propertyValue)) {
+  if (this->colorPicker.createColorPicker(propertyValue)) { // Returns true if the value was changed
     for (auto &&objectProperty : objectsProperty) {
       auto property = dynamic_cast<Property<ofColor> *>(objectProperty);
       property->setValue(propertyValue);
@@ -41,10 +44,10 @@ void PropertiesPanel::drawColorProperty(std::vector<PropertyBase *> &objectsProp
 }
 
 void PropertiesPanel::drawImageImport(std::vector<PropertyBase *> &objectsProperty) {
-  if (ImGui::Button("Import image", ImVec2(100.f, 30.f))) {
+  if (ImGui::Button("Import image", ImVec2(100.f, 30.f))) { // Returns true if the button was pressed
     ImageImporter::importImage(objectsProperty);
   }
-  if (ImGui::Button("Remove image", ImVec2(100.f, 30.f))) {
+  if (ImGui::Button("Remove image", ImVec2(100.f, 30.f))) { // Returns true if the button was pressed
     for (auto &&objectProperty : objectsProperty) {
       auto property = dynamic_cast<Property<ofImage> *>(objectProperty);
       property->getValue().clear();

--- a/src/properties/PropertiesPanel.cpp
+++ b/src/properties/PropertiesPanel.cpp
@@ -22,8 +22,8 @@ PropertiesPanel::PropertiesPanel() {
 void PropertiesPanel::drawFloatProperty(std::vector<PropertyBase *> &objectsProperty) {
   auto firstObjectProperty = dynamic_cast<Property<float> *>(objectsProperty[0]);
   auto propertyValue = firstObjectProperty->getValue();
-
-  if (ImGui::SliderFloat(toString(firstObjectProperty->getId()), &propertyValue, MIN_FLOAT_VALUE, MAX_FLOAT_VALUE, NULL)) { // Returns true if the value was changed
+  ImGui::SeparatorText(toString(firstObjectProperty->getId()));
+  if (ImGui::SliderFloat(" ", &propertyValue, MIN_FLOAT_VALUE, MAX_FLOAT_VALUE, NULL)) { // Returns true if the value was changed
     for (auto &&objectProperty : objectsProperty) {
       auto property = dynamic_cast<Property<float> *>(objectProperty);
       property->setValue(propertyValue);

--- a/src/properties/PropertiesPanel.cpp
+++ b/src/properties/PropertiesPanel.cpp
@@ -23,7 +23,7 @@ void PropertiesPanel::drawFloatProperty(std::vector<PropertyBase *> &objectsProp
   auto firstObjectProperty = dynamic_cast<Property<float> *>(objectsProperty[0]);
   auto propertyValue = firstObjectProperty->getValue();
 
-  if (ImGui::SliderFloat(toString(firstObjectProperty->getId()), &propertyValue, MIN_FLOAT_VALUE, MAX_FLOAT_VALUE, "size")) { // Returns true if the value was changed
+  if (ImGui::SliderFloat(toString(firstObjectProperty->getId()), &propertyValue, MIN_FLOAT_VALUE, MAX_FLOAT_VALUE, NULL)) { // Returns true if the value was changed
     for (auto &&objectProperty : objectsProperty) {
       auto property = dynamic_cast<Property<float> *>(objectProperty);
       property->setValue(propertyValue);

--- a/src/properties/PropertiesPanel.h
+++ b/src/properties/PropertiesPanel.h
@@ -6,12 +6,13 @@
 class PropertiesPanel {
 public:
   PropertiesPanel();
-  void drawFloatProperty(Property<float> *property);
-  void drawColorProperty(Property<ofColor> *property);
-  void drawImageImport(Property<ofImage> *property);
-  void drawPanel(std::vector<SceneObject *> &objects);
+  void drawFloatProperty(std::vector<PropertyBase *> &objectsProperty);
+  void drawColorProperty(std::vector<PropertyBase *> &objectsProperty);
+  void drawImageImport(std::vector<PropertyBase *> &objectsProperty);
+  void drawPropertiesPanel(std::vector<SceneObject *> &objects);
 
 private:
-  std::map<PROPERTY_ID, std::function<void(PropertyBase *)>> propertyDrawFunctions;
+  std::map<PROPERTY_ID, std::function<void(std::vector<PropertyBase *>)>> propertyDrawFunctions;
+  std::map<PROPERTY_ID, std::vector<PropertyBase *>> findCommonProperties(const std::vector<SceneObject *> &objects);
   ColorPicker colorPicker;
 };

--- a/src/properties/PropertiesPanel.h
+++ b/src/properties/PropertiesPanel.h
@@ -11,6 +11,9 @@ public:
   void drawImageImport(std::vector<PropertyBase *> &objectsProperty);
   void drawPropertiesPanel(std::vector<SceneObject *> &objects);
 
+  static const float MIN_FLOAT_VALUE;
+  static const float MAX_FLOAT_VALUE;
+
 private:
   std::map<PROPERTY_ID, std::function<void(std::vector<PropertyBase *>)>> propertyDrawFunctions;
   std::map<PROPERTY_ID, std::vector<PropertyBase *>> findCommonProperties(const std::vector<SceneObject *> &objects);

--- a/src/properties/Property.h
+++ b/src/properties/Property.h
@@ -2,9 +2,11 @@
 #include <string>
 
 enum class PROPERTY_ID {
-  SIZE,
+  // Place common properties here
   COLOR,
   IMAGE_IMPORT,
+  // Place object specific properties here
+  SIZE,
   RADIUS,
   HEIGHT
 };

--- a/src/properties/Property.h
+++ b/src/properties/Property.h
@@ -11,8 +11,8 @@ enum class PROPERTY_ID {
   HEIGHT
 };
 
-static inline const char *toString(PROPERTY_ID v) {
-  switch (v) {
+static inline const char *toString(PROPERTY_ID propertyId) {
+  switch (propertyId) {
     case PROPERTY_ID::SIZE:
       return "Size";
     case PROPERTY_ID::RADIUS:

--- a/src/scene/sceneGraph.cpp
+++ b/src/scene/sceneGraph.cpp
@@ -33,7 +33,11 @@ void SceneGraph::drawSceneGraphElements() {
     ImGui::EndChild();
 
     if (ImGui::IsItemClicked()) {
-      sceneManager.setSelectedSceneObject(sceneObjectPtr.get());
+      if (ImGui::IsKeyDown(ImGui::GetKeyIndex(ImGuiKey_LeftCtrl))) {
+        sceneManager.clickSelectionSceneObject(sceneObjectPtr.get());
+      } else {
+        sceneManager.setSelectedSceneObject(sceneObjectPtr.get());
+      }
     }
   }
 }

--- a/src/scene/sceneManager.cpp
+++ b/src/scene/sceneManager.cpp
@@ -47,18 +47,6 @@ void SceneManager::drawScene() {
   }
 }
 
-void SceneManager::drawPropertiesPanel() {
-  // TODO : Implement this
-  // ImGui::Text("Object Properties :");
-  // ImGui::Separator();
-  // if (!this->selectedSceneOject) {
-  //   return;
-  // }
-  // ImGui::BeginGroup();
-  // this->selectedSceneOject->draw_properties();
-  // ImGui::EndGroup();
-}
-
 const std::vector<std::unique_ptr<SceneObject>> &SceneManager::getObjects() const {
   return this->sceneObjects;
 }
@@ -71,10 +59,14 @@ void SceneManager::setSelectedSceneObject(const SceneObject *sceneObject) {
   }
 }
 
-void SceneManager::addSelectedSceneObject(const SceneObject *sceneObject) {
+void SceneManager::clickSelectionSceneObject(const SceneObject *sceneObject) {
   auto it = std::find_if(this->sceneObjects.begin(), this->sceneObjects.end(), [&](auto &&obj) { return obj.get() == sceneObject; });
   if (it != this->sceneObjects.end()) {
-    this->selectedSceneObjects.push_back(it->get());
+    if (std::find(this->selectedSceneObjects.begin(), this->selectedSceneObjects.end(), it->get()) != this->selectedSceneObjects.end()) {
+      this->selectedSceneObjects.erase(std::remove(this->selectedSceneObjects.begin(), this->selectedSceneObjects.end(), it->get()), this->selectedSceneObjects.end());
+    } else {
+      this->selectedSceneObjects.push_back(it->get());
+    }
   }
 }
 

--- a/src/scene/sceneManager.h
+++ b/src/scene/sceneManager.h
@@ -13,15 +13,15 @@ public:
   void removeObject(const SceneObject *sceneObject);
   void removeAllSelectedObjects();
   void drawScene();
-  void drawPropertiesPanel();
   const std::vector<std::unique_ptr<SceneObject>> &getObjects() const;
   void setSelectedSceneObject(const SceneObject *sceneObject);
-  void addSelectedSceneObject(const SceneObject *sceneObject);
+  void clickSelectionSceneObject(const SceneObject *sceneObject);
   const std::vector<SceneObject *> &getSelectedObject() const;
   std::vector<SceneObject *> &getSelectedObjectReference();
 
 private:
   void clearScene();
+
   std::vector<SceneObject *> selectedSceneObjects;
   std::vector<std::unique_ptr<SceneObject>> sceneObjects;
 };

--- a/src/scene/sceneObject.cpp
+++ b/src/scene/sceneObject.cpp
@@ -11,8 +11,7 @@ void SceneObject::draw(bool isSelected) {
   this->updateProperties();
   ofPushStyle();
   if (isSelected) {
-    ofColor complementaryColor(255 - this->color.r, 255 - this->color.g, 255 - this->color.b);
-    ofSetColor(complementaryColor);
+    ofSetColor(ofColor::white);
     primitive->drawWireframe();
   }
 

--- a/src/utils/ImageImporter.cpp
+++ b/src/utils/ImageImporter.cpp
@@ -1,15 +1,18 @@
 #include "ImageImporter.h"
 
-void ImageImporter::importImage(Property<ofImage> *property) {
+void ImageImporter::importImage(std::vector<PropertyBase *> objectsProperty) {
   ofFileDialogResult result = ofSystemLoadDialog("Load file");
   if (result.bSuccess) {
     string pathToLoad = result.getPath();
+    for (auto &&objectProperty : objectsProperty) {
+      auto property = dynamic_cast<Property<ofImage> *>(objectProperty);
 
-    if (property->getValue().load(pathToLoad)) {
-      property->setChanged(true);
-      ofLogNotice("ofApp") << "Image loaded successfully from: " << pathToLoad;
-    } else {
-      ofLogError("ofApp") << "Failed to load image from: " << pathToLoad;
+      if (property->getValue().load(pathToLoad)) {
+        property->setChanged(true);
+        ofLogNotice("ofApp") << "Image loaded successfully from: " << pathToLoad;
+      } else {
+        ofLogError("ofApp") << "Failed to load image from: " << pathToLoad;
+      }
     }
   }
 }

--- a/src/utils/ImageImporter.h
+++ b/src/utils/ImageImporter.h
@@ -4,5 +4,5 @@
 
 class ImageImporter {
 public:
-  static void importImage(Property<ofImage> *property);
+  static void importImage(std::vector<PropertyBase *> objectsProperty);
 };


### PR DESCRIPTION
Cette PR consiste principalement à faire l'implémentation de la sélection multiple, donc de venir sélectionner plusieurs éléments dans la scène en même temps.

De plus, lorsque qu'on sélectionne plusieurs éléments dans la scène notre panneau à droite contenant les propriétés vient seulement afficher les propriétés communes aux éléments sélectionnés. Une modification vient changer la valeur de chaque élément sélectionné.