### PR TITLE
Filtering 2.0

### DIFF
--- a/Infographie_IFT-3100.vcxproj
+++ b/Infographie_IFT-3100.vcxproj
@@ -192,6 +192,7 @@
     <ClCompile Include="..\..\addons\ofxImGui\libs\imgui\src\imgui_tables.cpp" />
     <ClCompile Include="..\..\addons\ofxImGui\libs\imgui\src\imgui_widgets.cpp" />
     <ClCompile Include="..\..\addons\ofxSvg\src\ofxSvg.cpp" />
+    <ClCompile Include="TexturePack.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\ofApp.h" />

--- a/Infographie_IFT-3100.vcxproj.filters
+++ b/Infographie_IFT-3100.vcxproj.filters
@@ -271,6 +271,9 @@
     <ClCompile Include="src\textures\TextureEditor.cpp">
       <Filter>src\textures</Filter>
     </ClCompile>
+    <ClCompile Include="TexturePack.cpp">
+      <Filter>src\textures</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="src">

--- a/TexturePack.cpp
+++ b/TexturePack.cpp
@@ -52,8 +52,6 @@ void TexturePack::configureTexture(ofTexture &texture) {
   glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, fLargest);
   glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
   texture.unbind();
-
-  texture.setTextureMinMagFilter(GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR);
 }
 
 void TexturePack::configureMaterial(std::shared_ptr<ofShader> shader) {

--- a/TexturePack.cpp
+++ b/TexturePack.cpp
@@ -16,6 +16,16 @@ void TexturePack::loadSingleImage(const ofImage &image, const std::string &id) {
   }
 }
 
+void TexturePack::setDiffuseMap(ofTexture &texture) {
+  /*textureDiffuseMap.allocate(texture.getWidth(), texture.getHeight(), texture.getTextureData().glInternalFormat);
+  configureTexture(texture);*/
+
+  textureDiffuseMap = texture;
+  if (textureDiffuseMap.isAllocated()) {
+    configureTexture(textureDiffuseMap);
+  }
+}
+
 bool TexturePack::load(const std::string &packName) {
   this->packId = packName;
   std::string filename = ofToLower(packName);

--- a/TexturePack.cpp
+++ b/TexturePack.cpp
@@ -1,0 +1,67 @@
+#include "TexturePack.h"
+
+TexturePack::TexturePack(const ofImage &image, const std::string &id) {
+  loadSingleImage(image, id);
+}
+
+TexturePack::TexturePack(const std::string &packName) {
+  load(packName);
+}
+
+void TexturePack::loadSingleImage(const ofImage &image, const std::string &id) {
+  this->packId = id;
+  textureDiffuseMap = image.getTexture();
+  if (textureDiffuseMap.isAllocated()) {
+    configureTexture(textureDiffuseMap);
+  }
+}
+
+bool TexturePack::load(const std::string &packName) {
+  this->packId = packName;
+  std::string filename = ofToLower(packName);
+
+  bool was_success = ofLoadImage(textureDiffuseMap, "textures/" + packName + "/" + filename + "_diff.jpg");
+  was_success |= ofLoadImage(textureNormalMap, "textures/" + packName + "/" + filename + "_nor_gl.jpg");
+  was_success |= ofLoadImage(textureDisplacementMap, "textures/" + packName + "/" + filename + "_disp.png");
+  was_success |= ofLoadImage(textureAORoughMetal, "textures/" + packName + "/" + filename + "_arm.jpg");
+
+  if (textureDiffuseMap.isAllocated()) {
+    configureTexture(textureDiffuseMap);
+  }
+  if (textureNormalMap.isAllocated()) {
+    configureTexture(textureNormalMap);
+  }
+  if (textureDisplacementMap.isAllocated()) {
+    configureTexture(textureDisplacementMap);
+  }
+  if (textureAORoughMetal.isAllocated()) {
+    configureTexture(textureAORoughMetal);
+  }
+
+  return was_success;
+}
+
+void TexturePack::configureTexture(ofTexture &texture) {
+  texture.setTextureWrap(GL_REPEAT, GL_REPEAT);
+  texture.generateMipmap();
+
+  GLfloat fLargest = 1.0;
+  glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &fLargest);
+
+  texture.bind();
+  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, fLargest);
+  glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
+  texture.unbind();
+
+  texture.setTextureMinMagFilter(GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR);
+}
+
+void TexturePack::configureMaterial(std::shared_ptr<ofShader> shader) {
+  material.setCustomShader(shader);
+  material.setAmbientColor(ofFloatColor(1, 1, 1, 0.6));
+  // set our textures on the material so that they will be passed to our custom shader
+  material.setCustomUniformTexture("mapDiffuse", textureDiffuseMap, 0);
+  material.setCustomUniformTexture("mapNormal", textureNormalMap, 1);
+  material.setCustomUniformTexture("mapDisplacement", textureDisplacementMap, 2);
+  material.setCustomUniformTexture("mapAORoughMetal", textureAORoughMetal, 3);
+}

--- a/TexturePack.cpp
+++ b/TexturePack.cpp
@@ -16,16 +16,6 @@ void TexturePack::loadSingleImage(const ofImage &image, const std::string &id) {
   }
 }
 
-void TexturePack::setDiffuseMap(ofTexture &texture) {
-  /*textureDiffuseMap.allocate(texture.getWidth(), texture.getHeight(), texture.getTextureData().glInternalFormat);
-  configureTexture(texture);*/
-
-  textureDiffuseMap = texture;
-  if (textureDiffuseMap.isAllocated()) {
-    configureTexture(textureDiffuseMap);
-  }
-}
-
 bool TexturePack::load(const std::string &packName) {
   this->packId = packName;
   std::string filename = ofToLower(packName);

--- a/src/properties/propertiesDraw/ImagePropertyDrawer.cpp
+++ b/src/properties/propertiesDraw/ImagePropertyDrawer.cpp
@@ -6,7 +6,6 @@
 
 void ImagePropertyDrawer::draw(std::vector<PropertyBase *> &objectsProperty) {
   drawImport(objectsProperty);
-  drawFiltering(objectsProperty);
 }
 
 void ImagePropertyDrawer::drawImport(const std::vector<PropertyBase *> &objectsProperty) {
@@ -23,29 +22,4 @@ void ImagePropertyDrawer::drawImport(const std::vector<PropertyBase *> &objectsP
       property->setChanged(true);
     }
   }*/
-}
-
-void ImagePropertyDrawer::drawFiltering(const std::vector<PropertyBase *> &objectsProperty) {
-  ImGui::SeparatorText("Filtering");
-
-  ImGui::Checkbox("Blur", &hasBlur);
-  ImGui::Checkbox("Sharpen", &hasSharpen);
-  ImGui::Checkbox("Grey", &hasGrey);
-
-  if (ImGui::Button("Apply", ImVec2(100.f, 30.f))) {
-    if (hasBlur) {
-      filtering.applyBlur(objectsProperty);
-      ofLogNotice("ImagePropertyDrawer") << "Apply Blur!";
-    }
-
-    if (hasSharpen) {
-      filtering.applySharpen(objectsProperty);
-      ofLogNotice("ImagePropertyDrawer") << "Apply Sharpen!";
-    }
-
-    if (hasGrey) {
-      filtering.applyGrey(objectsProperty);
-      ofLogNotice("ImagePropertyDrawer") << "Apply Grey!";
-    }
-  }
 }

--- a/src/properties/propertiesDraw/ImagePropertyDrawer.h
+++ b/src/properties/propertiesDraw/ImagePropertyDrawer.h
@@ -7,11 +7,5 @@ public:
   void draw(std::vector<PropertyBase *> &objectsProperty) override;
 
 private:
-  Filtering filtering;
-  bool hasBlur = false;
-  bool hasSharpen = false;
-  bool hasGrey = false;
-
   void drawImport(const std::vector<PropertyBase *> &objectsProperty);
-  void drawFiltering(const std::vector<PropertyBase *> &objectsProperty);
 };

--- a/src/scene/object/sceneObject.cpp
+++ b/src/scene/object/sceneObject.cpp
@@ -37,7 +37,3 @@ void SceneObject::setDraggingPositionOnObject(ofVec3f vec) {
 
 void SceneObject::stopDraggingObject() {
 }
-
-void SceneObject::setTexture(const TexturePack *texture) {
-  this->texture = texture;
-}

--- a/src/scene/object/sceneObject.h
+++ b/src/scene/object/sceneObject.h
@@ -8,38 +8,37 @@
 
 class SceneObject {
 public:
-	SceneObject();
-	virtual ~SceneObject() = default;
-	virtual void draw(bool isSelected, bool isBoundingBoxEnable, bool isObjectAxisEnable) const = 0;
-	const of3dPrimitive& getPrimitive() const;
-	const ofVec3f& getPosition() const;
-	virtual void setPosition(ofVec3f vec);
-	virtual void setDraggingPositionOnObject(ofVec3f vec);
-	virtual void stopDraggingObject();
-	void setTexture(const TexturePack* texture);
-	std::map<PROPERTY_ID, std::unique_ptr<PropertyBase>>& getProperties();
-	virtual void displayObjectOptions();
-	virtual void updateProperties();
+  SceneObject();
+  virtual ~SceneObject() = default;
+  virtual void draw(bool isSelected, bool isBoundingBoxEnable, bool isObjectAxisEnable) const = 0;
+  const of3dPrimitive &getPrimitive() const;
+  const ofVec3f &getPosition() const;
+  virtual void setPosition(ofVec3f vec);
+  virtual void setDraggingPositionOnObject(ofVec3f vec);
+  virtual void stopDraggingObject();
+  std::map<PROPERTY_ID, std::unique_ptr<PropertyBase>> &getProperties();
+  virtual void displayObjectOptions();
+  virtual void updateProperties();
 
-	template<typename T>
-	const T& getPropertyValue(const PROPERTY_ID& propertyName) const {
-		return dynamic_cast<Property<T> *>(this->properties.at(propertyName).get())->getValue();
-	}
+  template<typename T>
+  const T &getPropertyValue(const PROPERTY_ID &propertyName) const {
+    return dynamic_cast<Property<T> *>(this->properties.at(propertyName).get())->getValue();
+  }
 
-	template<typename T>
-	void addProperty(const PROPERTY_ID& propertyName, const T& initialValue) {
-		this->properties.emplace(std::make_pair(propertyName, std::make_unique<Property<T>>(propertyName, initialValue)));
-	}
+  template<typename T>
+  void addProperty(const PROPERTY_ID &propertyName, const T &initialValue) {
+    this->properties.emplace(std::make_pair(propertyName, std::make_unique<Property<T>>(propertyName, initialValue)));
+  }
 
 protected:
-	virtual void drawAxis() const = 0;
-	virtual void drawBoundingBox() const = 0;
+  virtual void drawAxis() const = 0;
+  virtual void drawBoundingBox() const = 0;
 
-	std::unique_ptr<of3dPrimitive> primitive;
-	std::map<PROPERTY_ID, std::unique_ptr<PropertyBase>> properties;
-	ofVec3f position;
-	glm::vec3 draggingPosition;
-	ofMesh mainMesh;
-	ofMaterial mMaterial;
-	const TexturePack* texture;
+  std::unique_ptr<of3dPrimitive> primitive;
+  std::map<PROPERTY_ID, std::unique_ptr<PropertyBase>> properties;
+  ofVec3f position;
+  glm::vec3 draggingPosition;
+  ofMesh mainMesh;
+  ofMaterial mMaterial;
+  const TexturePack *texture;
 };

--- a/src/textures/TextureEditor.cpp
+++ b/src/textures/TextureEditor.cpp
@@ -2,6 +2,30 @@
 
 #include "imgui.h"
 
+void TextureEditor::displayEditorOptions() {
+  ImGui::BeginGroup();
+  ImGui::SeparatorText("Texture Editor Options");
+  ImGui::Checkbox("Blur", &hasBlur);
+  ImGui::Checkbox("Sharpen", &hasSharpen);
+  ImGui::Checkbox("Grey", &hasGrey);
+
+  if (ImGui::Button("Apply", ImVec2(100.f, 30.f))) {
+    if (hasBlur) {
+      filtering.applyBlur(currentTexture);
+    }
+
+    if (hasSharpen) {
+      filtering.applySharpen(currentTexture);
+    }
+
+    if (hasGrey) {
+      filtering.applyGrey(currentTexture);
+    }
+  }
+
+  ImGui::EndGroup();
+}
+
 void TextureEditor::drawTextureEditor() {
   bool changed = false;
   auto &&pickerResult = texturePicker.drawTexturePicker(changed, currentTexture);
@@ -12,7 +36,8 @@ void TextureEditor::drawTextureEditor() {
   if (!currentTexture) {
     return;
   }
-
+  displayEditorOptions();
+  ImGui::SameLine();
   displayImage(currentTexture);
 }
 

--- a/src/textures/TextureEditor.cpp
+++ b/src/textures/TextureEditor.cpp
@@ -1,5 +1,7 @@
 #include "TextureEditor.h"
 
+#include "Filtering.h"
+#include "TextureRepository.h"
 #include "imgui.h"
 
 void TextureEditor::displayEditorOptions() {
@@ -11,15 +13,15 @@ void TextureEditor::displayEditorOptions() {
 
   if (ImGui::Button("Apply", ImVec2(100.f, 30.f))) {
     if (hasBlur) {
-      filtering.applyBlur(currentTexture);
+      TextureRepository::setTextureDiffuseMap(Filtering::applyBlur, currentTexture);
     }
 
     if (hasSharpen) {
-      filtering.applySharpen(currentTexture);
+      TextureRepository::setTextureDiffuseMap(Filtering::applySharpen, currentTexture);
     }
 
     if (hasGrey) {
-      filtering.applyGrey(currentTexture);
+      TextureRepository::setTextureDiffuseMap(Filtering::applyGrey, currentTexture);
     }
   }
 
@@ -46,5 +48,5 @@ void TextureEditor::setCurrentTexture(const TexturePack *texture) {
 }
 
 void TextureEditor::displayImage(const TexturePack *texture) {
-  ImGui::Image(reinterpret_cast<void *>(static_cast<intptr_t>(texture->textureDisplacementMap.getTextureData().textureID)), ImVec2(1024, 1024));
+  ImGui::Image(reinterpret_cast<void *>(static_cast<intptr_t>(texture->textureDiffuseMap.getTextureData().textureID)), ImVec2(1024, 1024));
 }

--- a/src/textures/TextureEditor.cpp
+++ b/src/textures/TextureEditor.cpp
@@ -12,16 +12,18 @@ void TextureEditor::displayEditorOptions() {
   ImGui::Checkbox("Grey", &hasGrey);
 
   if (ImGui::Button("Apply", ImVec2(100.f, 30.f))) {
+    auto &id = currentTexture->packId;
+
     if (hasBlur) {
-      TextureRepository::setTextureDiffuseMap(Filtering::applyBlur, currentTexture);
+      TextureRepository::setTextureDiffuseMap(Filtering::applyBlur, id);
     }
 
     if (hasSharpen) {
-      TextureRepository::setTextureDiffuseMap(Filtering::applySharpen, currentTexture);
+      TextureRepository::setTextureDiffuseMap(Filtering::applySharpen, id);
     }
 
     if (hasGrey) {
-      TextureRepository::setTextureDiffuseMap(Filtering::applyGrey, currentTexture);
+      TextureRepository::setTextureDiffuseMap(Filtering::applyGrey, id);
     }
   }
 

--- a/src/textures/TextureEditor.h
+++ b/src/textures/TextureEditor.h
@@ -11,4 +11,8 @@ public:
 private:
   TexturePicker texturePicker;
   const TexturePack *currentTexture{nullptr};
+
+  bool hasBlur{false};
+  bool hasSharpen{false};
+  bool hasGrey{false};
 };

--- a/src/textures/TextureEditor.h
+++ b/src/textures/TextureEditor.h
@@ -3,6 +3,7 @@
 
 class TextureEditor {
 public:
+  void displayEditorOptions();
   void drawTextureEditor();
   void setCurrentTexture(const TexturePack *texture);
   static void displayImage(const TexturePack *texture);

--- a/src/textures/TexturePack.h
+++ b/src/textures/TexturePack.h
@@ -10,7 +10,6 @@ public:
   TexturePack(const std::string &packName);
 
   void loadSingleImage(const ofImage &image, const std::string &id);
-  void setDiffuseMap(ofTexture &texture);
 
   bool load(const std::string &packName);
   void configureTexture(ofTexture &texture);

--- a/src/textures/TexturePack.h
+++ b/src/textures/TexturePack.h
@@ -6,71 +6,16 @@
 class TexturePack {
 public:
   TexturePack() = default;
-  TexturePack(const ofImage &image, const std::string &id) {
-    loadSingleImage(image, id);
-  }
+  TexturePack(const ofImage &image, const std::string &id);
+  TexturePack(const std::string &packName);
 
-  TexturePack(const std::string &packName) {
-    load(packName);
-  }
+  void loadSingleImage(const ofImage &image, const std::string &id);
+  void setDiffuseMap(ofImage image);
 
-  void loadSingleImage(const ofImage &image, const std::string &id) {
-    this->packId = id;
-    textureDiffuseMap = image.getTexture();
-    if (textureDiffuseMap.isAllocated()) {
-      configureTexture(textureDiffuseMap);
-    }
-  }
+  bool load(const std::string &packName);
+  void configureTexture(ofTexture &texture);
+  void configureMaterial(std::shared_ptr<ofShader> shader);
 
-  bool load(const std::string &packName) {
-    this->packId = packName;
-    std::string filename = ofToLower(packName);
-
-    bool was_success = ofLoadImage(textureDiffuseMap, "textures/" + packName + "/" + filename + "_diff.jpg");
-    was_success |= ofLoadImage(textureNormalMap, "textures/" + packName + "/" + filename + "_nor_gl.jpg");
-    was_success |= ofLoadImage(textureDisplacementMap, "textures/" + packName + "/" + filename + "_disp.png");
-    was_success |= ofLoadImage(textureAORoughMetal, "textures/" + packName + "/" + filename + "_arm.jpg");
-
-    if (textureDiffuseMap.isAllocated()) {
-      configureTexture(textureDiffuseMap);
-    }
-    if (textureNormalMap.isAllocated()) {
-      configureTexture(textureNormalMap);
-    }
-    if (textureDisplacementMap.isAllocated()) {
-      configureTexture(textureDisplacementMap);
-    }
-    if (textureAORoughMetal.isAllocated()) {
-      configureTexture(textureAORoughMetal);
-    }
-
-    return was_success;
-  };
-
-  void configureTexture(ofTexture &texture) {
-    texture.setTextureWrap(GL_REPEAT, GL_REPEAT);
-    texture.generateMipmap();
-
-    GLfloat fLargest = 1.0;
-    glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &fLargest);
-
-    texture.bind();
-    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, fLargest);
-    glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
-    texture.unbind();
-
-    texture.setTextureMinMagFilter(GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR);
-  }
-
-  void configureMaterial(std::shared_ptr<ofShader> shader) {
-    material.setCustomShader(shader);
-    material.setAmbientColor(ofFloatColor(1, 1, 1, 0.6));
-    // set our textures on the material so that they will be passed to our custom shader
-    material.setCustomUniformTexture("mapDiffuse", textureDiffuseMap, 0);
-    material.setCustomUniformTexture("mapNormal", textureNormalMap, 1);
-    material.setCustomUniformTexture("mapDisplacement", textureDisplacementMap, 2);
-    material.setCustomUniformTexture("mapAORoughMetal", textureAORoughMetal, 3);
-  }
   // diffuse texture map holds the color information
   ofTexture textureDiffuseMap;
   // texture holding the normal values for the mesh that will be used for lighting in the frag shader
@@ -86,4 +31,9 @@ public:
   ofFloatColor baseColor;
 
   std::string packId;
+  ofPixels defaultPixels;
+
+  bool hasBlur;
+  bool hasSharpen;
+  bool hasGrey;
 };

--- a/src/textures/TexturePack.h
+++ b/src/textures/TexturePack.h
@@ -10,7 +10,7 @@ public:
   TexturePack(const std::string &packName);
 
   void loadSingleImage(const ofImage &image, const std::string &id);
-  void setDiffuseMap(ofImage image);
+  void setDiffuseMap(ofTexture &texture);
 
   bool load(const std::string &packName);
   void configureTexture(ofTexture &texture);
@@ -32,8 +32,4 @@ public:
 
   std::string packId;
   ofPixels defaultPixels;
-
-  bool hasBlur;
-  bool hasSharpen;
-  bool hasGrey;
 };

--- a/src/textures/TextureRepository.cpp
+++ b/src/textures/TextureRepository.cpp
@@ -26,3 +26,11 @@ const TexturePack *TextureRepository::getTexture(const std::string &packId) {
   }
   return it->get();
 }
+
+void TextureRepository::setTextureDiffuseMap(std::function<void(ofTexture &)> callback, const TexturePack *texture) {
+  auto &textureDiffuseMap = texture->textureDiffuseMap;
+  auto &id = texture->packId;
+
+  auto it = std::find_if(textures.begin(), textures.end(), [&](auto &&element) { return element->packId == id; });
+  callback(it->get()->textureDiffuseMap);
+}

--- a/src/textures/TextureRepository.cpp
+++ b/src/textures/TextureRepository.cpp
@@ -27,10 +27,7 @@ const TexturePack *TextureRepository::getTexture(const std::string &packId) {
   return it->get();
 }
 
-void TextureRepository::setTextureDiffuseMap(std::function<void(ofTexture &)> callback, const TexturePack *texture) {
-  auto &textureDiffuseMap = texture->textureDiffuseMap;
-  auto &id = texture->packId;
-
+void TextureRepository::setTextureDiffuseMap(std::function<void(ofTexture &)> callback, const std::string &id) {
   auto it = std::find_if(textures.begin(), textures.end(), [&](auto &&element) { return element->packId == id; });
   callback(it->get()->textureDiffuseMap);
 }

--- a/src/textures/TextureRepository.h
+++ b/src/textures/TextureRepository.h
@@ -15,5 +15,5 @@ public:
 
 private:
   static void setTextureDisplacementMap();
-  static void setTextureDiffuseMap(std::function<void(ofTexture &)> callback, const TexturePack *texture);
+  static void setTextureDiffuseMap(std::function<void(ofTexture &)> callback, const std::string &id);
 };

--- a/src/textures/TextureRepository.h
+++ b/src/textures/TextureRepository.h
@@ -15,4 +15,5 @@ public:
 
 private:
   static void setTextureDisplacementMap();
+  static void setTextureDiffuseMap(std::function<void(ofTexture &)> callback, const TexturePack *texture);
 };

--- a/src/utils/Filtering.cpp
+++ b/src/utils/Filtering.cpp
@@ -54,13 +54,7 @@ void Filtering::applyConvolution(const ofPixels &inputPixels, ofPixels &outputPi
 }
 
 void Filtering::updateTexture(ofTexture &texture, const ofPixels &outputPixels) {
-  // 1
   texture.loadData(outputPixels);
-
-  // 2
-  /*texture.bind();
-  glTexSubImage2D(texture.texData.textureTarget, 0, 0, 0, outputPixels.getWidth(), outputPixels.getHeight(), ofGetGlInternalFormat(outputPixels), GL_UNSIGNED_BYTE, outputPixels.getData());
-  texture.unbind();*/
 }
 
 void Filtering::applyToAll(ofTexture &texture, std::function<void(const ofPixels &, ofPixels &)> callback) {

--- a/src/utils/Filtering.h
+++ b/src/utils/Filtering.h
@@ -5,12 +5,13 @@
 
 class Filtering {
 public:
-  void applyBlur(const std::vector<PropertyBase *> &objectsProperty);
-  void applySharpen(const std::vector<PropertyBase *> &objectsProperty);
-  void applyGrey(const std::vector<PropertyBase *> &objectsProperty);
+  static void applyBlur(ofTexture &texture);
+  static void applySharpen(ofTexture &texture);
+  static void applyGrey(ofTexture &texture);
 
 private:
-  void applyConvolution(const ofImage &inputImage, ofImage &outputImage, const std::array<float, 9> &convolution);
-  void updateInputImage(ofImage &inputImage, const ofImage &outputImage);
-  void applyToAll(const std::vector<PropertyBase *> &objectsProperty, std::function<void(ofImage &, ofImage &)> callback);
+  static void applyConvolution(const ofPixels &inputPixels, ofPixels &outputPixels, const std::array<float, 9> &convolution);
+  static void updateTexture(ofTexture &texture, const ofPixels &outputPixels);
+  static void applyToAll(ofTexture &texture, std::function<void(const ofPixels &, ofPixels &)> callback);
+  static ofPixels getPixels(const ofTexture &texture);
 };


### PR DESCRIPTION
- `Filtering` est maintenant dans `TextureEditor`
- Fix bug lorsqu'on se rapprochait et s'élognait avec la caméra et qu'un filtrage était appliqué:
```cpp
void TexturePack::configureTexture(ofTexture &texture) {
  texture.setTextureWrap(GL_REPEAT, GL_REPEAT);
  texture.generateMipmap();

  GLfloat fLargest = 1.0;
  glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &fLargest);

  texture.bind();
  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, fLargest);
  glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
  texture.unbind();

  // texture.setTextureMinMagFilter(GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR); // Retirer cette ligne
}
```